### PR TITLE
Nested UL, OL helpers are not rendered correctly

### DIFF
--- a/gluon/html.py
+++ b/gluon/html.py
@@ -1683,17 +1683,30 @@ class UL(DIV):
     """
     UL Component.
 
-    If subcomponents are not LI-components they will be wrapped in a LI
+    If subcomponents are not LI,OL or UL -components they will be wrapped in a LI
+
+
+    >>> UL("appease", LI("them"), "with", LI("a shrubbery"), UL("Ni","Ni","Ni")).xml()
+    '<ul><li>appease</li><li>them</li><li>with</li><li>a shrubbery</li><ul><li>Ni</li><li>Ni</li><li>Ni</li></ul></ul>'
 
     """
 
     tag = 'ul'
 
     def _fixup(self):
-        self._wrap_components(LI, LI)
+        self._wrap_components((LI,UL,OL), LI)
 
 
 class OL(UL):
+    """
+    OL Component.
+
+    If subcomponents are not LI,OL or UL -components they will be wrapped in a LI
+
+    >>> OL("appease", LI("them"), "with", LI("a shrubbery"), OL("Ni","Ni","Ni")).xml()
+    '<ol><li>appease</li><li>them</li><li>with</li><li>a shrubbery</li><ol><li>Ni</li><li>Ni</li><li>Ni</li></ol></ol>'
+
+    """
 
     tag = 'ol'
 
@@ -2854,3 +2867,4 @@ def ASSIGNJS(**kargs):
 if __name__ == '__main__':
     import doctest
     doctest.testmod()
+


### PR DESCRIPTION
## description of the behaviour

when trying to render nested list helpers (UL,OL), an extra LI Element is inserted
```python
>>> OL("appease", LI("them"), "with", LI("a shrubbery"), OL("Ni","Ni","Ni")).xml()
'<ol><li>appease</li><li>them</li><li>with</li><li>a shrubbery</li><li><ol><li>Ni</li><li>Ni</li><li>Ni</li></ol></li></ol>'
```
which, as rendered by the browser, looks like:


1. appease
2. them
3. with 
4. a shrubbery
5. 
   1. Ni
   2. Ni
   3. Ni

the correct result should be:
```python
>>> OL("appease", LI("them"), "with", LI("a shrubbery"), OL("Ni","Ni","Ni")).xml()
'<ol><li>appease</li><li>them</li><li>with</li><li>a shrubbery</li><ol><li>Ni</li><li>Ni</li><li>Ni</li></ol></ol>'
```
which in turn, as rendered by the browser, looks somewhat like:
1. appease
2. them
3. with 
4. a shrubbery
   1. Ni
   2. Ni
   3. Ni

## web2py version

(as stated in the file ``web2py/VERSION``)
Version 2.15.3-stable+timestamp.2017.08.07.12.51.45

## reason for incorrect rendering
missing components in _fixup()

## fix

adding components which are allowed to be nested inside UL/OL